### PR TITLE
Fix: Inconsistent Param for Analytics

### DIFF
--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -14,7 +14,7 @@ import { AdminGuard } from 'src/auth/guards/admin.guard';
 @Controller('leaderboard')
 export class LeaderboardController {
   constructor(private readonly leaderboardService: LeaderboardService) {}
-
+  secondsToMilliseconds = 1000;
   @UseGuards(JwtAuthGuard)
   @Get('top-users')
   async getTopUsers(
@@ -42,8 +42,8 @@ export class LeaderboardController {
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
   ) {
-    const parseStartDate = startDate ? new Date(Number(startDate)) : undefined;
-    const parseEndDate = endDate ? new Date(Number(endDate)) : new Date();
+    const parseStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
+    const parseEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
     return this.leaderboardService.getCompanyValueAnalytics(
       parseStartDate,
       parseEndDate,
@@ -58,8 +58,8 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate)) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate)) : new Date();
+    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
+    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds ) : new Date();
     return this.leaderboardService.getTopRecognitionReceivers(
       page,
       limit,
@@ -76,8 +76,8 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate)) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate)) : new Date();
+    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
+    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
     return this.leaderboardService.getTopRecognitionSenders(
       page,
       limit,
@@ -119,8 +119,8 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate)) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate)) : new Date();
+    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
+    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
 
     return await this.leaderboardService.totalCoinAndRecognitionGiven(
       parsedStartDate,
@@ -134,8 +134,8 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate)) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate)) : new Date();
+    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
+    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
     return await this.leaderboardService.cumulativePostMetrics(
       parsedStartDate,
       parsedEndDate,

--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -14,7 +14,7 @@ import { AdminGuard } from 'src/auth/guards/admin.guard';
 @Controller('leaderboard')
 export class LeaderboardController {
   constructor(private readonly leaderboardService: LeaderboardService) {}
-  secondsToMilliseconds = 1000;
+  private readonly MILLISECONDS_IN_SECOND = 1000;
   @UseGuards(JwtAuthGuard)
   @Get('top-users')
   async getTopUsers(
@@ -42,8 +42,12 @@ export class LeaderboardController {
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
   ) {
-    const parseStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
-    const parseEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
+    const parseStartDate = startDate
+      ? new Date(Number(startDate) * this.MILLISECONDS_IN_SECOND)
+      : undefined;
+    const parseEndDate = endDate
+      ? new Date(Number(endDate) * this.MILLISECONDS_IN_SECOND)
+      : new Date();
     return this.leaderboardService.getCompanyValueAnalytics(
       parseStartDate,
       parseEndDate,
@@ -58,8 +62,12 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds ) : new Date();
+    const parsedStartDate = startDate
+      ? new Date(Number(startDate) * this.MILLISECONDS_IN_SECOND)
+      : undefined;
+    const parsedEndDate = endDate
+      ? new Date(Number(endDate) * this.MILLISECONDS_IN_SECOND)
+      : new Date();
     return this.leaderboardService.getTopRecognitionReceivers(
       page,
       limit,
@@ -76,8 +84,12 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
+    const parsedStartDate = startDate
+      ? new Date(Number(startDate) * this.MILLISECONDS_IN_SECOND)
+      : undefined;
+    const parsedEndDate = endDate
+      ? new Date(Number(endDate) * this.MILLISECONDS_IN_SECOND)
+      : new Date();
     return this.leaderboardService.getTopRecognitionSenders(
       page,
       limit,
@@ -119,8 +131,12 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
+    const parsedStartDate = startDate
+      ? new Date(Number(startDate) * this.MILLISECONDS_IN_SECOND)
+      : undefined;
+    const parsedEndDate = endDate
+      ? new Date(Number(endDate) * this.MILLISECONDS_IN_SECOND)
+      : new Date();
 
     return await this.leaderboardService.totalCoinAndRecognitionGiven(
       parsedStartDate,
@@ -134,8 +150,12 @@ export class LeaderboardController {
     @Query('startDate') startDate?: number,
     @Query('endDate') endDate?: number,
   ) {
-    const parsedStartDate = startDate ? new Date(Number(startDate) * this.secondsToMilliseconds) : undefined;
-    const parsedEndDate = endDate ? new Date(Number(endDate) * this.secondsToMilliseconds) : new Date();
+    const parsedStartDate = startDate
+      ? new Date(Number(startDate) * this.MILLISECONDS_IN_SECOND)
+      : undefined;
+    const parsedEndDate = endDate
+      ? new Date(Number(endDate) * this.MILLISECONDS_IN_SECOND)
+      : new Date();
     return await this.leaderboardService.cumulativePostMetrics(
       parsedStartDate,
       parsedEndDate,


### PR DESCRIPTION
## Describe your changes
This PR addresses the inconsistent betweent the parameters expected for the Analytics Endpoint Filter.

### What process, pages or flows are affected by these changes.

### Does this PR fulfill these requirements?
- [x] It does not introduce code for which logic is already written (i.e. utilizes reusability)
- [x] It has been checked for spelling and grammar errors
- [ ] When resolving a specific issue, it is referenced in the PR's title (e.g. `feature: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have reviewed the **Files changed** tab and removed unnecessary console logs introduced in this PR
- [x] I have assigned the reviewer(s) for this issue
- [ ] This feature requires a feature flag.

### Test
- [x] I have reviewed that the feature works correctly on my local environment
- [x] I am properly handling errors
- [ ] I have written appropriate tests for the feature where necessary

## Ticket link

## Screenshot(s)

https://github.com/Helium-Health/helium-kudos-server/pull/343



https://github.com/user-attachments/assets/b7b2b4db-983e-444f-8cae-64576b75f199




